### PR TITLE
Bs to ssc calibration

### DIFF
--- a/+acoustics/Sv2SSC.m
+++ b/+acoustics/Sv2SSC.m
@@ -27,7 +27,7 @@ classdef Sv2SSC < handle
         % ADCP objects to be used for calibration
         %
         % see also: Sv2SSC, ADCP
-        adcp (:,1) ADCP
+        adcp (:,1) VMADCP {mustBeScalarOrEmpty} = rdi.VMADCP.empty
         
         % acoustics.Sv2SSC/samples property
         %


### PR DESCRIPTION
Updated backscatter calibration following Sassi's method:
- Coefficient b is now calculated from a linear fit between log(K_ref) and Sv/10 which is NOT going through the origin.
- Empty sample data are now excluded from calibration.
- Removed double pieces of code.
Only files in +acoustics were changed.